### PR TITLE
Fix for compatible with libpcap-1.10.x

### DIFF
--- a/pcaputil.c
+++ b/pcaputil.c
@@ -58,7 +58,7 @@ pcap_dloff(pcap_t *pd)
 }
 
 pcap_t *
-pcap_init(char *intf, char *filter, int snaplen)
+pcaputil_pcap_init(char *intf, char *filter, int snaplen)
 {
 	pcap_t *pd;
 	u_int net, mask;

--- a/pcaputil.h
+++ b/pcaputil.h
@@ -11,7 +11,7 @@
 #ifndef PCAPUTIL_H
 #define PCAPUTIL_H
 
-pcap_t *pcap_init(char *intf, char *filter, int snaplen);
+pcap_t *pcaputil_pcap_init(char *intf, char *filter, int snaplen);
 
 int	pcap_dloff(pcap_t *pd);
 

--- a/tcpkill.c
+++ b/tcpkill.c
@@ -141,7 +141,7 @@ main(int argc, char *argv[])
 	
 	filter = copy_argv(argv);
 	
-	if ((pd = pcap_init(intf, filter, 64)) == NULL)
+	if ((pd = pcaputil_pcap_init(intf, filter, 64)) == NULL)
 		errx(1, "couldn't initialize sniffing");
 
 	if ((pcap_off = pcap_dloff(pd)) < 0)


### PR DESCRIPTION
https://github.com/the-tcpdump-group/libpcap/commit/028ce6676bcfc813e581f95f4797666043cb5475#diff-7bf09c17e375167d7b3654e46296dadbe9ddbfed045dff27e630da58e87b22ecR385

Type conflict with version `libpcap-1.10.x`